### PR TITLE
type cast state key to string

### DIFF
--- a/src/Metadata/MetadataStore.php
+++ b/src/Metadata/MetadataStore.php
@@ -31,7 +31,7 @@ class MetadataStore implements MetadataStoreInterface
     public function state($state, $key = null, $default = null)
     {
         foreach ($this->config['states'] as $value) {
-            if ($value['name'] === $state) {
+            if ($value['name'] == $state) {
                 return $this->get($value, $key, $default);
             }
         }

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -108,10 +108,10 @@ class StateMachine extends BaseStateMachine
         }
 
         if (is_null($subject)) {
-            return $this->metadataStore->state((string) $this->getState(), $key, $default);
+            return $this->metadataStore->state($this->getState(), $key, $default);
         }
 
-        return $this->metadataStore->state((string) $this->getState(), $subject, $key);
+        return $this->metadataStore->state($this->getState(), $subject, $key);
     }
 
     protected function getTransitionMetadata($subject, $key, $default)

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -108,10 +108,10 @@ class StateMachine extends BaseStateMachine
         }
 
         if (is_null($subject)) {
-            return $this->metadataStore->state($this->getState(), $key, $default);
+            return $this->metadataStore->state((string) $this->getState(), $key, $default);
         }
 
-        return $this->metadataStore->state($this->getState(), $subject, $key);
+        return $this->metadataStore->state((string) $this->getState(), $subject, $key);
     }
 
     protected function getTransitionMetadata($subject, $key, $default)

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -65,7 +65,7 @@ class StateMachine extends BaseStateMachine
     protected function hasState($state)
     {
         foreach ($this->config['states'] as $value) {
-            if ($value['name'] === $state) {
+            if ($value['name'] == $state) {
                 return true;
             }
         }

--- a/tests/StateMachine/StateMachineTest.php
+++ b/tests/StateMachine/StateMachineTest.php
@@ -39,7 +39,7 @@ class StateMachineTest extends TestCase
 
         // Assert
 
-        $this->assertEquals('pending_review', (string) $sm->getState());
+        $this->assertEquals('pending_review', $sm->getState());
     }
 
     /**

--- a/tests/StateMachine/StateMachineTest.php
+++ b/tests/StateMachine/StateMachineTest.php
@@ -39,7 +39,7 @@ class StateMachineTest extends TestCase
 
         // Assert
 
-        $this->assertEquals('pending_review', $sm->getState());
+        $this->assertEquals('pending_review', (string) $sm->getState());
     }
 
     /**


### PR DESCRIPTION
Some developers (including me) use Enum packages to maintain the states and <code>StateMachine->getState()</code> returns the enum instance in that case. 
```php
'states' => [
            [
                'name' => ProfileState::NewProfile,
                'metadata' => [
                    'class' => 'secondary',
                    'display_name' => 'Unapproved Profile',
                    'initial' => true,
                    'final' => false,
                    'employee_can_edit' => true,
                ]
            ]
```

You're assuming the state name is always string by default when trying to get its metadata and it couldn't find a matching state if enums are used. If you type cast the state name to string , everything works fine. 
All tests are passing.

Thank you for this awesome package. Love your work 💯 

PS: https://github.com/BenSampo/laravel-enum#attribute-casting for your reference