### PR TITLE
Added command to generate image of graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 build
 composer.lock
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
   - php: 7.3
   - php: 7.4
 
++before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install graphviz
+
 before_script:
   - phpenv config-rm xdebug.ini
   - composer self-update --stable --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require-dev": {
         "mockery/mockery": "^1.3.1",
         "orchestra/testbench": "^5.0",
-        "phpunit/phpunit": "^8.4 | ^9.0"
+        "phpunit/phpunit": "^8.4 | ^9.0",
+        "symfony/process": "^4.3 | ^5.0"
     },
     "repositories": [
         {

--- a/src/Commands/Visualize.php
+++ b/src/Commands/Visualize.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Sebdesign\SM\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class Visualize extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'winzou:state-machine:visualize
+        {graph? : A state machine graph}
+        {--output=./graph.jpg}
+        {--format=jpg}
+        {--direction=TB}
+        {--shape=circle}
+        {--dot-path=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generates an image of the states and transitions of state machine graphs';
+
+    protected $config;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        parent::__construct();
+
+        $this->config = $config;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (empty($this->config)) {
+            $this->error('There are no state machines configured.');
+
+            return 1;
+        }
+
+        if (! $this->argument('graph')) {
+            $this->askForGraph();
+        }
+
+        $graph = $this->argument('graph');
+
+        if (! array_key_exists($graph, $this->config)) {
+            $this->error('The provided state machine graph is not configured.');
+
+            return 1;
+        }
+
+        $config = $this->config[$graph];
+
+        $this->stateMachineInDotFormat($config);
+
+        return 0;
+    }
+
+    /**
+     * Ask for a graph name if one was not provided as argument.
+     */
+    protected function askForGraph()
+    {
+        $choices = array_map(function ($name, $config) {
+            return $name."\t(".$config['class'].' - '.$config['graph'].')';
+        }, array_keys($this->config), $this->config);
+
+        $choice = $this->choice('Which state machine would you like to know about?', $choices, 0);
+
+        $choice = substr($choice, 0, strpos($choice, "\t"));
+
+        $this->info('You have just selected: '.$choice);
+
+        $this->input->setArgument('graph', $choice);
+    }
+
+    protected function stateMachineInDotFormat(array $config)
+    {
+        // Output image mime types.
+        $mimeTypes = [
+            'png' => 'image/png',
+            'jpg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'svg' => 'image/svg+xml',
+        ];
+
+        $format = $this->option('format');
+
+        if (empty($mimeTypes[$format])) {
+            throw new \Exception(sprintf("Format '%s' is not supported", $format));
+        }
+
+        $dotPath = $this->option('dot-path') ?? 'dot';
+        $outputImage = $this->option('output');
+
+        $process = new Process([$dotPath, '-T', $format, '-o', $outputImage]);
+        $process->setInput($this->buildDotFile($config));
+        $process->run();
+
+        // executes after the command finishes
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    protected function buildDotFile(array $config): string
+    {
+        // Display settings
+        $layout = $this->option('direction') === 'TB' ? 'TB' : 'LR';
+        $nodeShape = $this->option('shape');
+
+        // Build dot file content.
+        $result = [];
+        $result[] = 'digraph finite_state_machine {';
+        $result[] = "rankdir={$layout};";
+        $result[] = 'node [shape = point]; _start_'; // Input node
+
+        // Use first value from 'states' as start.
+        $start = $config['states'][0]['name'];
+        $result[] = "node [shape = {$nodeShape}];"; // Default nodes
+        $result[] = "_start_ -> {$start};"; // Input node -> starting node.
+
+        foreach ($config['transitions'] as $name => $transition) {
+            foreach ($transition['from'] as $from) {
+                $result[] = "{$from} -> {$transition['to']} [label = \"{$name}\"];";
+            }
+        }
+
+        $result[] = '}';
+
+        return implode(PHP_EOL, $result);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,7 @@ use Laravel\Lumen\Application as LumenApplication;
 use Sebdesign\SM\Callback\ContainerAwareCallback;
 use Sebdesign\SM\Callback\ContainerAwareCallbackFactory;
 use Sebdesign\SM\Commands\Debug;
+use Sebdesign\SM\Commands\Visualize;
 use Sebdesign\SM\Event\Dispatcher;
 use Sebdesign\SM\Factory\Factory;
 use SM\Callback\CallbackFactoryInterface;
@@ -96,8 +97,13 @@ class ServiceProvider extends BaseServiceProvider
             return new Debug($app->make('config')->get('state-machine', []));
         });
 
+        $this->app->bind(Visualize::class, function ($app) {
+            return new Visualize($app->make('config')->get('state-machine', []));
+        });
+
         $this->commands([
             Debug::class,
+            Visualize::class,
         ]);
     }
 

--- a/tests/Commands/VisualizeTest.php
+++ b/tests/Commands/VisualizeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Sebdesign\SM\Test\Commands;
+
+use Illuminate\Contracts\Console\Kernel;
+use Sebdesign\SM\Test\ConsoleHelpers;
+use Sebdesign\SM\Test\TestCase;
+
+class VisualizeTest extends TestCase
+{
+    use ConsoleHelpers;
+
+    /**
+     * @test
+     */
+    public function it_generates_an_image()
+    {
+        if (! `which dot`) {
+            $this->markTestSkipped('Dot executable not found.');
+        }
+
+        // Arrange
+
+        $config = $this->app['config']->get('state-machine', []);
+        $command = \Mockery::spy('\Sebdesign\SM\Commands\Visualize[choice]', [$config]);
+
+        $this->app[Kernel::class]->registerCommand($command);
+
+        // Act
+
+        $outputImage = tempnam(sys_get_temp_dir(), 'smv');
+        $this->artisan('winzou:state-machine:visualize', [
+            'graph' => 'graphA',
+            '--no-interaction' => true,
+            '--output' => $outputImage,
+        ]);
+
+        // Assert
+        $this->withSuccessCode();
+
+        $this->assertTrue(file_exists($outputImage));
+    }
+}


### PR DESCRIPTION
This PR introduces a new command to generate an image of a given graph.
It's taken from the corresponding bundle for Symfony: [https://github.com/MadMind/StateMachineVisualizationBundle](https://github.com/MadMind/StateMachineVisualizationBundle), so all credits goes to the original author.

## Requirements

If you want to run this command, you need to have installed **dot** - Part of graphviz package ([http://www.graphviz.org/](http://www.graphviz.org/)). In your mac, this is equal to having run ```brew install graphviz```

## Usage:

```php artisan winzou:state-machine:visualize {graph? : A state machine graph} {--output=./graph.jpg} {--format=jpg} {--direction=TB} {--shape=circle} {--dot-path=/usr/local/bin/dot}```

## Example Output

![test](https://user-images.githubusercontent.com/1104083/75524206-bcfd1a00-5a0d-11ea-9dce-aa0d61e46e75.jpg)



