### PR TITLE
Allow arrays in metadata

### DIFF
--- a/src/Commands/Debug.php
+++ b/src/Commands/Debug.php
@@ -103,14 +103,7 @@ class Debug extends Command
             }
 
             if (isset($state['metadata'])) {
-                $metadata = implode(PHP_EOL, array_map(function ($value, $key) {
-                    $value = is_array($value) ? 'Array' : $value;
-                    if (is_bool($value)) {
-                        $value = $value ? 'true' : 'false';
-                    }
-
-                    return vsprintf('%s: %s', [$key, $value]);
-                }, $state['metadata'], array_keys($state['metadata'])));
+                $metadata = json_encode($state['metadata'], JSON_PRETTY_PRINT);
             } else {
                 $metadata = null;
             }

--- a/src/Commands/Debug.php
+++ b/src/Commands/Debug.php
@@ -104,6 +104,11 @@ class Debug extends Command
 
             if (isset($state['metadata'])) {
                 $metadata = implode(PHP_EOL, array_map(function ($value, $key) {
+                    $value = is_array($value) ? 'Array' : $value;
+                    if (is_bool($value)) {
+                        $value = $value ? 'true' : 'false';
+                    }
+
                     return vsprintf('%s: %s', [$key, $value]);
                 }, $state['metadata'], array_keys($state['metadata'])));
             } else {


### PR DESCRIPTION
If we store arrays in metadata, the debug command throws ‘array to string conversion’ error. I’m not sure whether to print the array data as well and how many levels to traverse if we were to print the arrays.
So this PR will display simple ‘Array’ as value.
Also right now it prints ‘1’ for boolean true and nothing for boolean false since ‘%s’ is used in sprintf. So i’m manually casting it to string. Please feel free to edit the PR code as you see fit.

Thank you.