### PR TITLE
Quote state and transition names

### DIFF
--- a/src/Commands/Visualize.php
+++ b/src/Commands/Visualize.php
@@ -136,11 +136,11 @@ class Visualize extends Command
         // Use first value from 'states' as start.
         $start = $config['states'][0]['name'];
         $result[] = "node [shape = {$nodeShape}];"; // Default nodes
-        $result[] = "_start_ -> {$start};"; // Input node -> starting node.
+        $result[] = "_start_ -> \"{$start}\";"; // Input node -> starting node.
 
         foreach ($config['transitions'] as $name => $transition) {
             foreach ($transition['from'] as $from) {
-                $result[] = "{$from} -> {$transition['to']} [label = \"{$name}\"];";
+                $result[] = "\"{$from}\" -> \"{$transition['to']}\" [label = \"{$name}\"];";
             }
         }
 


### PR DESCRIPTION
The state and transition names can contain dashes, and those result in a syntax error in the generated dot file.