### PR TITLE
PHP 7.4 incompatible array-style access of non-arrays

### DIFF
--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -65,7 +65,7 @@ class StateMachine extends BaseStateMachine
     protected function hasState($state)
     {
         foreach ($this->config['states'] as $value) {
-            if ($value['name'] === $state) {
+            if (is_array($value) && $value['name'] === $state) {
                 return true;
             }
         }


### PR DESCRIPTION
Fix for following backwards incompatible change in PHP 7.4:

https://www.php.net/manual/de/migration74.incompatible.php#migration74.incompatible.core.non-array-access